### PR TITLE
Add Card Style for BookDetails and Reviews page

### DIFF
--- a/app/dtos.py
+++ b/app/dtos.py
@@ -11,6 +11,8 @@ class BookInfo:
     page_count: Optional[int] = None
     thumbnail_url: Optional[str] = None
     small_thumbnail_url: Optional[str] = None
+    image_small_url: Optional[str] = None
+    image_medium_url: Optional[str] = None
     google_books_id: Optional[str] = None
 
 

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -1,3 +1,4 @@
+from logging import info
 from typing import List, Optional
 from uuid import UUID
 
@@ -15,28 +16,30 @@ class Query:
 
     @strawberry.field
     def review(self, uuid: UUID) -> Optional[ReviewInfoType]:
-        review_data = get_review_info(uuid)
-        if review_data is not None:
+        info = get_review_info(uuid)
+        if info is not None:
             return ReviewInfoType(
-                uuid=review_data.uuid,
-                text=review_data.text,
-                book=review_data.book,
+                uuid=info.uuid,
+                text=info.text,
+                book=info.book,
             )
 
     @strawberry.field
     def book(self, uuid: UUID) -> Optional[BookInfoType]:
         # Fetch data from your data source
-        book_data = get_book_info(uuid)
-        if book_data is not None:
+        info = get_book_info(uuid)
+        if info is not None:
             return BookInfoType(
-                uuid=book_data.uuid,
-                title=book_data.title,
-                authors=book_data.authors,
-                pub_date=book_data.pub_date,
-                page_count=book_data.page_count,
-                thumbnail_url=book_data.thumbnail_url,
-                small_thumbnail_url=book_data.small_thumbnail_url,
-                google_books_id=book_data.google_books_id,
+                uuid=info.uuid,
+                title=info.title,
+                authors=info.authors,
+                pub_date=info.pub_date,
+                page_count=info.page_count,
+                thumbnail_url=info.thumbnail_url,
+                small_thumbnail_url=info.small_thumbnail_url,
+                image_small_url=info.image_small_url,
+                image_medium_url=info.image_medium_url,
+                google_books_id=info.google_books_id,
             )
         return None
 

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -1,4 +1,3 @@
-from logging import info
 from typing import List, Optional
 from uuid import UUID
 

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -12,6 +12,8 @@ class BookInfoType:
     page_count: Optional[int] = None
     thumbnail_url: Optional[str] = None
     small_thumbnail_url: Optional[str] = None
+    image_small_url: Optional[str] = None
+    image_medium_url: Optional[str] = None
     google_books_id: Optional[str] = None
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,7 +8,8 @@ from app.models import Book, Review
 
 from .dtos import BookInfo, ReviewInfo
 
-# Google recommends only fetching desired fields e.g. `?fields=id,volumeInfo(title,authors,imageLinks/thumbnail)`
+# Google recommends only fetching desired
+# fields e.g. `?fields=id,volumeInfo(title,authors,imageLinks/thumbnail)`
 GOOGLE_BOOKS_API_URL = "https://www.googleapis.com/books/v1/volumes/{volume_id}"
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -8,6 +8,7 @@ from app.models import Book, Review
 
 from .dtos import BookInfo, ReviewInfo
 
+# Google recommends only fetching desired fields e.g. `?fields=id,volumeInfo(title,authors,imageLinks/thumbnail)`
 GOOGLE_BOOKS_API_URL = "https://www.googleapis.com/books/v1/volumes/{volume_id}"
 
 
@@ -99,5 +100,7 @@ def fetch_book_data(uuid: UUID, volume_id: str) -> Optional[BookInfo]:
         pub_date=volume_info.get("publishedDate"),
         page_count=volume_info.get("pageCount"),
         thumbnail_url=image_links.get("thumbnail"),
-        small_thumbnail_url=image_links.get("smallThumbnail"),
+        small_thumbnail_url=image_links.get("smallThumbnailUrl"),
+        image_small_url=image_links.get("small"),
+        image_medium_url=image_links.get("medium"),
     )

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -1,8 +1,43 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import BookReviews from "./Screens/Reviews";
-import { Navigate, Route, Routes } from "react-router-dom";
+import Reviews from "./Screens/Reviews";
+import {
+  createBrowserRouter,
+  Navigate,
+  RouterProvider,
+} from "react-router-dom";
 import NotFound from "./Screens/NotFound";
 import BookDetails from "./Screens/BookDetails";
+
+// TODO: split into different routers per children to have them cleaner e.g. Books, App, Reviews, etc.
+const router = createBrowserRouter([
+  {
+    path: "/",
+    children: [
+      {
+        // Redirect by default to /reviews
+        index: true,
+        element: <Navigate to="/reviews" replace />,
+      },
+      {
+        path: "reviews",
+        element: <Reviews />,
+      },
+      {
+        path: "books",
+        children: [
+          {
+            path: ":uuid",
+            element: <BookDetails />,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    path: "*",
+    element: <NotFound />,
+  },
+]);
 
 const queryClient = new QueryClient();
 
@@ -10,12 +45,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <h1>Platonica</h1>
-      <Routes>
-        <Route path={"/"} element={<Navigate to="/reviews" replace />} />
-        <Route path={"/reviews"} element={<BookReviews />} />
-        <Route path={"*"} element={<NotFound />} />
-        <Route path="/books/:uuid" element={<BookDetails />} />
-      </Routes>
+      <RouterProvider router={router} />
     </QueryClientProvider>
   );
 }

--- a/web-app/src/Screens/BookCover.tsx
+++ b/web-app/src/Screens/BookCover.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { styled } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 
 interface BookCoverProps {
   imageUrl: string;
+  fallbackImageUrl?: string;
   onClick?: () => void;
   bookName?: string;
   width?: number | string;
@@ -43,14 +44,16 @@ const StyledImage = styled("img")({
 
 const BookCover: React.FC<BookCoverProps> = ({
   imageUrl,
+  fallbackImageUrl,
   onClick,
   bookName = "Book cover",
   width = 120,
   height = 180,
 }) => {
+  const srcUrl = imageUrl?.trim() ? imageUrl : fallbackImageUrl;
   return (
     <StyledCover width={width} height={height} onClick={onClick}>
-      <StyledImage src={imageUrl} alt={bookName} />
+      <StyledImage src={srcUrl} alt={bookName} />
     </StyledCover>
   );
 };

--- a/web-app/src/Screens/BookDetails.tsx
+++ b/web-app/src/Screens/BookDetails.tsx
@@ -5,14 +5,15 @@ import { useParams } from "react-router-dom";
 import {
   Alert,
   Box,
+  Typography,
+  CircularProgress,
   Card,
   CardContent,
-  CardMedia,
-  CircularProgress,
-  Typography,
+  Divider,
 } from "@mui/material";
+import BookCover from "./BookCover";
 
-const GetBookReviewsQuery = gql`
+const GetBookQuery = gql`
   query GetBook($uuid: UUID!) {
     book(uuid: $uuid) {
       uuid
@@ -22,6 +23,8 @@ const GetBookReviewsQuery = gql`
       pageCount
       thumbnailUrl
       smallThumbnailUrl
+      imageSmallUrl
+      imageMediumUrl
       googleBooksId
     }
   }
@@ -32,7 +35,7 @@ function BookDetails() {
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["book", uuid],
-    queryFn: () => graphQLClient.request(GetBookReviewsQuery, { uuid }),
+    queryFn: () => graphQLClient.request(GetBookQuery, { uuid }),
     enabled: !!uuid,
   });
 
@@ -52,35 +55,84 @@ function BookDetails() {
     );
   }
 
-  const { title, authors, pubDate, pageCount, googleBooksId } = data.book;
+  const {
+    title,
+    authors,
+    pubDate,
+    pageCount,
+    imageMediumUrl: imageUrl,
+    thumbnailUrl,
+    googleBooksId,
+  } = data.book;
 
   return (
-    <Box display="flex" justifyContent="center" mt={4}>
-      <Card sx={{ maxWidth: 600, width: "100%" }}>
-        <CardContent>
-          <Typography variant="h5" component="div" gutterBottom>
-            {title}
-          </Typography>
-          {authors && authors.length > 0 && (
-            <Typography variant="subtitle1" color="text.secondary">
-              {authors.join(", ")}
+    <Box p={4} display="flex" justifyContent="center">
+      <Card sx={{ display: "flex", width: "100%", maxWidth: 1200 }}>
+        <CardContent
+          sx={{
+            display: "flex",
+            width: "100%",
+            gap: 4,
+            flexDirection: { xs: "column", md: "row" },
+          }}
+        >
+          {/* Left Column: Content */}
+          <Box flex={1}>
+            <Typography variant="h4" gutterBottom>
+              Welcome to the Library
             </Typography>
-          )}
-          {pubDate && (
-            <Typography variant="body2" color="text.secondary">
-              Published: {pubDate}
+            <Typography variant="body1" paragraph>
+              Discover insightful reads and timeless classics. Our collection is
+              curated with care to fuel your curiosity and inspire your
+              imagination.
             </Typography>
-          )}
-          {pageCount && (
-            <Typography variant="body2" color="text.secondary">
-              Pages: {pageCount}
+            <Typography variant="body1" paragraph>
+              Whether you're researching for a project or escaping into a novel,
+              you'll find something that captures your interest and keeps you
+              turning the pages.
             </Typography>
-          )}
-          {googleBooksId && (
-            <Typography variant="body2" color="text.secondary">
-              Google Books ID: {googleBooksId}
+            <Typography variant="body1" paragraph>
+              Dive in and explore a world of ideas. Use the sidebar to learn
+              more about any book in our digital collection.
             </Typography>
-          )}
+          </Box>
+
+          {/* Vertical Divider */}
+          <Divider
+            orientation="vertical"
+            flexItem
+            sx={{ display: { xs: "none", md: "block" } }}
+          />
+
+          {/* Right Column: Book Details */}
+          <Box width={200} flexShrink={0}>
+            <Box
+              sx={{
+                marginBottom: "20px",
+              }}
+            >
+              <BookCover
+                bookName={title}
+                imageUrl={imageUrl}
+                fallbackImageUrl={thumbnailUrl}
+                width={"100%"}
+                height={"100%"}
+              />
+            </Box>
+            <Typography variant="h6" fontWeight="bold">
+              {title}
+            </Typography>
+            {authors && authors.length > 0 && (
+              <Typography variant="subtitle2" color="textPrimary">
+                {authors.join(", ")}
+              </Typography>
+            )}
+            {pageCount && (
+              <Typography variant="subtitle2" color="text.secondary">
+                Pages: {pageCount}
+              </Typography>
+            )}
+          </Box>
         </CardContent>
       </Card>
     </Box>

--- a/web-app/src/Screens/NotFound.tsx
+++ b/web-app/src/Screens/NotFound.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography, Button } from "@mui/material";
-import { Link as RouterLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 function NotFound() {
   return (
@@ -21,12 +21,7 @@ function NotFound() {
       <Typography variant="body1" sx={{ mb: 3 }}>
         Sorry, the page you're looking for doesn't exist.
       </Typography>
-      <Button
-        variant="outlined"
-        color="secondary"
-        component={RouterLink}
-        to="/"
-      >
+      <Button variant="outlined" color="secondary" component={Link} to="/">
         Go to Homepage
       </Button>
     </Box>

--- a/web-app/src/Screens/Reviews.tsx
+++ b/web-app/src/Screens/Reviews.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { gql } from "graphql-request";
 import { graphQLClient } from "../graphqlClient";
 import BookCover from "./BookCover";
-import { Box, Grid, Typography } from "@mui/material";
+import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 
@@ -13,12 +13,13 @@ const GetBookReviewsQuery = gql`
         uuid
         title
         thumbnailUrl
+        smallThumbnailUrl
       }
     }
   }
 `;
 
-function BookReviews() {
+function Reviews() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ["reviews"],
     queryFn: () => graphQLClient.request(GetBookReviewsQuery),
@@ -30,7 +31,7 @@ function BookReviews() {
 
   useEffect(() => {
     if (bookUUID) {
-      navigate(`/books/${bookUUID}`, { replace: true });
+      navigate(`/books/${bookUUID}`);
     }
   }, [navigate, bookUUID]);
 
@@ -38,43 +39,55 @@ function BookReviews() {
   if (isError) return <div>Error!</div>;
 
   return (
-    <>
-      <Box
-        id="reviews-list"
-        sx={{
-          margin: "20px",
-        }}
-      >
-        <Typography variant="h5" component="h2" gutterBottom>
-          Reviews
-        </Typography>
-        <Grid
-          container
-          spacing={2}
-          direction="row"
+    <Box p={4} display="flex" justifyContent="center">
+      <Card sx={{ display: "flex", width: "100%", maxWidth: 1200 }}>
+        <CardContent
           sx={{
-            justifyContent: "flex-start",
-            alignItems: "center",
+            display: "flex",
+            width: "100%",
+            gap: 4,
+            flexDirection: { xs: "column", md: "row" },
           }}
         >
-          {data.reviews.map((r) => {
-            const { title, thumbnailUrl, uuid } = r.book;
-            return (
-              <Grid>
-                <BookCover
-                  bookName={title}
-                  imageUrl={thumbnailUrl}
-                  onClick={() => {
-                    setBookUUID(uuid);
-                  }}
-                />
-              </Grid>
-            );
-          })}
-        </Grid>
-      </Box>
-    </>
+          <Box
+            id="reviews-list"
+            sx={{
+              margin: "10px",
+            }}
+          >
+            <Typography variant="h5" component="h2" gutterBottom>
+              Reviews
+            </Typography>
+            <Grid
+              container
+              spacing={2}
+              direction="row"
+              sx={{
+                justifyContent: "flex-start",
+                alignItems: "center",
+              }}
+            >
+              {data.reviews.map((r) => {
+                const { title, thumbnailUrl, smallThumbnailUrl, uuid } = r.book;
+                return (
+                  <Grid key={`book-grid-item-${uuid}`}>
+                    <BookCover
+                      bookName={title}
+                      imageUrl={thumbnailUrl}
+                      fallbackImageUrl={smallThumbnailUrl}
+                      onClick={() => {
+                        setBookUUID(uuid);
+                      }}
+                    />
+                  </Grid>
+                );
+              })}
+            </Grid>
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
   );
 }
 
-export default BookReviews;
+export default Reviews;

--- a/web-app/src/main.tsx
+++ b/web-app/src/main.tsx
@@ -1,13 +1,7 @@
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
-import { BrowserRouter } from "react-router-dom";
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
-);
-root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <App />
 );


### PR DESCRIPTION
- Uses now `createBrowserRouter` for routing 
- Improves the BookDetails page
- Includes fallback images in case higher quality ones are not there (still relies on what GoogleBooks API returns)

<img width="904" alt="Screenshot 2025-04-16 at 10 48 33 PM" src="https://github.com/user-attachments/assets/498949af-c4ef-4e2b-903c-9af7334fdb00" />
<img width="911" alt="Screenshot 2025-04-16 at 10 48 40 PM" src="https://github.com/user-attachments/assets/3f69582b-6d6c-45f4-9442-34749f0b392a" />

To consider:
- Have a real default image whenever the image source couldn't be retrieved.
- BookDetails should be only having details, currently it has a bit more, which would be then the actual Review Page.