### PR TITLE
Add Cookie-based JWT authentication flow

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -38,6 +38,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
+          GOOGLE_BOOKS_API_KEY: somekey
         ports: ["5480:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -38,7 +38,6 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
-          GOOGLE_BOOKS_API_KEY: somekey
         ports: ["5480:5432"]
         options: >-
           --health-cmd pg_isready
@@ -48,6 +47,7 @@ jobs:
 
     env:
       DEBUG: true
+      GOOGLE_BOOKS_API_KEY: somekey
     #   POSTGRES_USER: postgres
     #   POSTGRES_PASSWORD: postgres
     #   POSTGRES_DB: test_db

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -85,4 +85,4 @@ jobs:
           python manage.py migrate
 
       - name: Run tests
-        run: python manage.py test
+        run: make run-tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ wheels/
 
 # Virtual environments
 .venv
+.env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.pytestArgs": ["app"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,6 @@ ruff-check:
 	@echo "Checking files' format..."
 	@(ruff check . && ruff format . --check)
 	
+run-tests:
+	@echo "Running tests"
+	@(pytest --maxfail=1)

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -1,0 +1,31 @@
+from rest_framework.request import Request
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import AuthenticationFailed, InvalidToken
+
+# cookie names
+ACCESS_COOKIE = "access"
+REFRESH_COOKIE = "refresh"
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """
+    First tries the Authorization header, then looks for an "access" cookie.
+    """
+
+    def authenticate(self, request: Request):
+        # Try the default header logic
+        header_auth = super().authenticate(request)
+        if header_auth is not None:
+            return header_auth
+
+        # Fallback to cookie
+        raw_token = request.COOKIES.get(ACCESS_COOKIE)
+        if not raw_token:
+            return None
+
+        try:
+            validated_token = self.get_validated_token(raw_token)
+            user = self.get_user(validated_token)
+            return (user, validated_token)
+        except (InvalidToken, AuthenticationFailed):
+            return None

--- a/app/tests/test_jwt_auth.py
+++ b/app/tests/test_jwt_auth.py
@@ -1,0 +1,146 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from django.conf import settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from app.authentication import ACCESS_COOKIE, REFRESH_COOKIE
+
+# Reusable credentials
+USERNAME = "alice"
+PASSWORD = "StrongPass!123"
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user(django_user_model):
+    return django_user_model.objects.create_user(username=USERNAME, password=PASSWORD)
+
+
+@pytest.fixture
+def raw_login_response(api_client, user):
+    """
+    Calls the login endpoint, returning the full response so we can
+    inspect its cookies.
+    """
+    return api_client.post(
+        reverse("token_obtain_pair"),
+        {"username": user.username, "password": PASSWORD},
+    )
+
+
+@pytest.fixture
+def tokens(raw_login_response):
+    """
+    Extracts access & refresh tokens from the cookies set on login.
+    """
+    resp = raw_login_response
+    assert resp.status_code == status.HTTP_200_OK
+    # response.cookies is a SimpleCookie
+    access = resp.cookies[ACCESS_COOKIE].value
+    refresh = resp.cookies[REFRESH_COOKIE].value
+    return access, refresh
+
+
+@pytest.mark.parametrize(
+    "username,password",
+    [
+        ("noone", "wrongpass"),
+        (USERNAME, "badpass"),
+    ],
+)
+@pytest.mark.django_db
+def test_invalid_credentials_fail_obtain(api_client, username, password):
+    resp = api_client.post(
+        reverse("token_obtain_pair"),
+        {
+            "username": username,
+            "password": password,
+        },
+    )
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+    # no cookies should be set
+    assert ACCESS_COOKIE not in resp.cookies
+    assert REFRESH_COOKIE not in resp.cookies
+
+
+@pytest.mark.django_db
+def test_obtain_token_pair(raw_login_response):
+    assert raw_login_response.status_code == status.HTTP_200_OK
+    cookies = raw_login_response.cookies
+    assert ACCESS_COOKIE in cookies, "access cookie missing"
+    assert REFRESH_COOKIE in cookies, "refresh cookie missing"
+
+
+@pytest.mark.django_db
+def test_refresh_rotates_and_returns_new_pair(api_client, tokens):
+    old_access, old_refresh = tokens
+
+    # load the refresh token into the client's cookie jar
+    api_client.cookies[REFRESH_COOKIE] = old_refresh
+
+    # call the refresh endpoint (no body needed)
+    resp = api_client.post(reverse("token_refresh"))
+
+    assert resp.status_code == status.HTTP_200_OK
+
+    # ensure both cookies were updated
+    new_access = resp.cookies[ACCESS_COOKIE].value
+    new_refresh = resp.cookies[REFRESH_COOKIE].value
+
+    assert new_access != old_access, "access token was not rotated"
+    assert new_refresh != old_refresh, "refresh token was not rotated"
+
+
+@pytest.mark.django_db
+def test_logout_revokes_refresh_and_prevents_further_refresh(api_client, tokens):
+    access, refresh = tokens
+
+    # set both cookies so logout can read them
+    api_client.cookies[ACCESS_COOKIE] = access
+    api_client.cookies[REFRESH_COOKIE] = refresh
+
+    # perform logout
+    resp = api_client.post(reverse("auth_logout"))
+    assert resp.status_code == status.HTTP_205_RESET_CONTENT
+
+    # the response should clear the cookies (max_age=0)
+    cleared = resp.cookies
+    assert ACCESS_COOKIE in cleared and cleared[ACCESS_COOKIE]["max-age"] == 0
+    assert REFRESH_COOKIE in cleared and cleared[REFRESH_COOKIE]["max-age"] == 0
+
+    # attempt to refresh again
+    api_client.cookies.clear()  # no refresh cookie
+    retry = api_client.post(reverse("token_refresh"))
+    assert retry.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_refresh_with_invalid_token(api_client):
+    api_client.cookies[REFRESH_COOKIE] = "not.a.valid.jwt"
+    resp = api_client.post(reverse("token_refresh"))
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_refresh_with_expired_token(api_client, user):
+    # Arrange: craft a refresh token that's already expired
+    payload = {
+        "token_type": "refresh",
+        "user_id": user.id,
+        "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+    }
+    expired_token = jwt.encode(
+        payload, settings.SECRET_KEY, algorithm=settings.SIMPLE_JWT["ALGORITHM"]
+    )
+
+    api_client.cookies[REFRESH_COOKIE] = expired_token
+    response = api_client.post(reverse("token_refresh"))
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,12 +1,36 @@
-from django.urls import path
+from django.urls import path, re_path
 from django.views.decorators.csrf import csrf_exempt
-from strawberry.django.views import GraphQLView
 
 from . import views
 from .graphql.schema import schema
+from .views import (
+    CookieTokenObtainPairView,
+    CookieTokenRefreshView,
+    JWTProtectedGraphQLView,
+    LogoutAndBlacklistView,
+)
 
 urlpatterns = [
     path("", views.index, name="index"),
-    # FOR PRODUCTION handle CSRF tokens properly and remove exemption
-    path("graphql", csrf_exempt(GraphQLView.as_view(schema=schema)), name="graphql"),
+    re_path(
+        r"^api/token/?$",
+        csrf_exempt(CookieTokenObtainPairView.as_view()),
+        name="token_obtain_pair",
+    ),
+    re_path(
+        r"^api/token/refresh/?$",
+        csrf_exempt(CookieTokenRefreshView.as_view()),
+        name="token_refresh",
+    ),
+    re_path(
+        "^api/logout/?$",
+        csrf_exempt(LogoutAndBlacklistView.as_view()),
+        name="auth_logout",
+    ),
+    # FIXME: FOR PRODUCTION handle CSRF tokens properly and remove exemption
+    re_path(
+        r"^graphql/?$",
+        csrf_exempt(JWTProtectedGraphQLView.as_view(schema=schema, graphiql=True)),
+        name="graphql",
+    ),
 ]

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,12 +5,14 @@ from uuid import UUID
 import requests
 
 from app.models import Book, Review
+from project import settings
 
 from .dtos import BookInfo, ReviewInfo
 
-# Google recommends only fetching desired
+# TODO: Google recommends only fetching desired
 # fields e.g. `?fields=id,volumeInfo(title,authors,imageLinks/thumbnail)`
-GOOGLE_BOOKS_API_URL = "https://www.googleapis.com/books/v1/volumes/{volume_id}"
+GOOGLE_BOOKS_API_URL = "https://www.googleapis.com/books/v1"
+REQUEST_TIMEOUT_SECS = 5
 
 
 def get_reviews() -> Optional[List[ReviewInfo]]:
@@ -90,7 +92,17 @@ def get_book_from_db(uuid: UUID) -> Optional[Book]:
 def fetch_book_data(uuid: UUID, volume_id: str) -> Optional[BookInfo]:
     """Fetches book metadata from Google Books API and returns selected fields."""
     try:
-        response = requests.get(GOOGLE_BOOKS_API_URL.format(volume_id=volume_id))
+        params = {
+            "key": settings.GOOGLE_BOOKS_API_KEY,
+        }
+        response = requests.get(
+            "{api_url}/volumes/{volume_id}".format(
+                api_url=GOOGLE_BOOKS_API_URL,
+                volume_id=volume_id,
+            ),
+            params,
+            timeout=REQUEST_TIMEOUT_SECS,
+        )
         response.raise_for_status()
     except requests.RequestException as e:
         print(f"[ERROR] Failed to fetch book '{volume_id}': {e}")

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,150 @@
-from django.http import HttpResponse
+from datetime import timedelta
 
-# Create your views here.
+from django.http import HttpResponse, JsonResponse
+from rest_framework import permissions, status
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken, TokenError
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
+from strawberry.django.views import GraphQLView
+
+from app.authentication import ACCESS_COOKIE, REFRESH_COOKIE, CookieJWTAuthentication
+from project import settings
+
+
+class JWTProtectedGraphQLView(GraphQLView):
+    def dispatch(self, request, *args, **kwargs):
+        try:
+            auth_res = CookieJWTAuthentication().authenticate(request)
+            if auth_res is None:
+                raise AuthenticationFailed(
+                    "Authentication credentials were not provided"
+                )
+            request.user, request.auth = auth_res
+        except AuthenticationFailed as e:
+            return JsonResponse({"errors": [{"message": str(e)}]}, status=401)
+        return super().dispatch(request, *args, **kwargs)
+
+
+class CookieTokenObtainPairView(TokenObtainPairView):
+    """
+    POST /api/token/
+    Response sets two HttpOnly cookies: access & refresh
+    """
+
+    permission_classes = (permissions.AllowAny,)
+
+    def post(self, request, *args, **kwargs):
+        # call the built‑in method from TokenObtainPairView to validate credentials
+        response = super().post(request, *args, **kwargs)
+        if response.status_code != status.HTTP_200_OK:
+            return response
+
+        # response as:
+        #     {
+        #     "refresh": "<string>",
+        #     "access": "<string>"
+        # }
+        tokens = response.data
+        access_token = tokens["access"]
+        refresh_token = tokens["refresh"]
+
+        # Build a new response (drop tokens from body if you like)
+        data = {"detail": "Login successful"}
+        cookie_resp = Response(data, status=status.HTTP_200_OK)
+
+        # Set the cookies
+        _set_access_cookie(http_response=cookie_resp, value=access_token)
+        _set_refresh_cookie(http_response=cookie_resp, value=refresh_token)
+        return cookie_resp
+
+
+class CookieTokenRefreshView(TokenRefreshView):
+    """
+    POST /api/token/refresh/
+    Reads refresh cookie, rotates tokens in cookies
+    """
+
+    permission_classes = (permissions.AllowAny,)
+
+    def post(self, request, *args, **kwargs):
+        # Inject the cookie into request.data for DRF to pick it up
+        request.data["refresh"] = request.COOKIES.get(REFRESH_COOKIE, "")
+
+        response = super().post(request, *args, **kwargs)
+        if response.status_code != status.HTTP_200_OK:
+            return response
+
+        tokens = response.data
+        new_access = tokens["access"]
+        new_refresh = tokens["refresh"]
+
+        data = {"detail": "Token refreshed"}
+        cookie_resp = Response(data, status=status.HTTP_200_OK)
+
+        _set_access_cookie(http_response=cookie_resp, value=new_access)
+        _set_refresh_cookie(http_response=cookie_resp, value=new_refresh)
+        return cookie_resp
+
+
+def _set_access_cookie(http_response: Response, value: str):
+    http_response.set_cookie(
+        key=ACCESS_COOKIE,
+        value=value,
+        httponly=True,
+        secure=True,
+        samesite="Strict",
+        max_age=_cookie_expiry(settings.SIMPLE_JWT["ACCESS_TOKEN_LIFETIME"]),
+    )
+
+
+def _set_refresh_cookie(http_response: Response, value: str):
+    http_response.set_cookie(
+        key=REFRESH_COOKIE,
+        value=value,
+        httponly=True,
+        secure=True,
+        samesite="Strict",
+        max_age=_cookie_expiry(settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"]),
+    )
+
+
+def _cookie_expiry(delta: timedelta) -> int:
+    """Return max_age in seconds for a timedelta"""
+    return int(delta.total_seconds())
+
+
+class LogoutAndBlacklistView(APIView):
+    """
+    POST /api/logout/
+    Reads refresh cookie, invalidates it, stores in blacklist and deletes cookies
+    """
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request):
+        refresh_token = request.COOKIES.get(REFRESH_COOKIE, None)
+        if not refresh_token:
+            return Response(
+                {"detail": "No refresh token provided."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+        except TokenError:
+            pass  # malformed or already expired; ignore
+
+        # clear cookies
+        resp = Response({"detail": "Logged out"}, status=status.HTTP_205_RESET_CONTENT)
+        resp.delete_cookie(ACCESS_COOKIE)
+        resp.delete_cookie(REFRESH_COOKIE)
+        return resp
 
 
 def index(request):

--- a/project/settings.py
+++ b/project/settings.py
@@ -10,16 +10,32 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
+from datetime import timedelta
 from pathlib import Path
+
+import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# initialize env, read .env file
+env = environ.Env(
+    DEBUG=(bool, False),
+    # you can declare default casting here
+)
+environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
+
+
+#  ENV Variables here:
+GOOGLE_BOOKS_API_KEY = env("GOOGLE_BOOKS_API_KEY")
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
+# FIXME: make it an ENV variable
 SECRET_KEY = "django-insecure-z#x!@mzr&g!da=dt_)54k+!rauc7rpi)4a)!k_s_kuss2-injc"
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -28,19 +44,20 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
 # Application definition
 
 INSTALLED_APPS = [
-    "corsheaders",
-    "strawberry_django",
     "app.apps.AppConfig",
+    "corsheaders",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.sessions",
     "django.contrib.staticfiles",
+    "rest_framework_simplejwt.token_blacklist",
+    "rest_framework",
+    "strawberry_django",
 ]
 
 MIDDLEWARE = [
@@ -53,6 +70,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+APPEND_SLASH = True
 
 ROOT_URLCONF = "project.urls"
 
@@ -70,6 +89,24 @@ TEMPLATES = [
         },
     },
 ]
+
+#  AUTHENTICATION using JWT
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "app.authentication.CookieJWTAuthentication",  # custom authenticator
+    ),
+}
+
+# settings api: https://django-rest-framework-simplejwt.readthedocs.io/en/latest/
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=10),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=3),
+    "ROTATE_REFRESH_TOKENS": True,
+    "BLACKLIST_AFTER_ROTATION": True,
+    # TODO: use RS256 algorithm when having RS256 to
+    # avoid sharing the secret on all services.
+    "ALGORITHM": "HS256",
+}
 
 WSGI_APPLICATION = "project.wsgi.application"
 
@@ -102,6 +139,8 @@ DATABASES = {
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",  # Vite dev server
 ]
+# If Sending cookies (withCredentials: true)
+CORS_ALLOW_CREDENTIALS = True
 
 CSRF_TRUSTED_ORIGINS = [
     "http://localhost:5173",  # Vite dev server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ requires-python = ">=3.10"
 dependencies = [
     "django>=5.2",
     "django-cors-headers>=4.7.0",
+    "django-environ>=0.12.0",
+    "djangorestframework>=3.16.0",
+    "djangorestframework-simplejwt>=5.5.0",
     "psycopg>=3.2.6",
+    "pytest>=8.3.5",
+    "pytest-django>=4.11.1",
     "requests>=2.32.3",
     "strawberry-graphql>=0.264.0",
     "strawberry-graphql-django>=0.58.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = project.settings
+
+# auto‑discover any file named tests.py or test_*.py
+python_files = tests.py test_*.py

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
 name = "django"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -105,13 +114,18 @@ source = { virtual = "." }
 dependencies = [
     { name = "django" },
     { name = "django-cors-headers" },
+    { name = "django-environ" },
+    { name = "djangorestframework" },
+    { name = "djangorestframework-simplejwt" },
     { name = "psycopg" },
+    { name = "pytest" },
+    { name = "pytest-django" },
     { name = "requests" },
     { name = "strawberry-graphql" },
     { name = "strawberry-graphql-django" },
 ]
 
-[package.dev-dependencies]
+[package.optional-dependencies]
 dev = [
     { name = "ruff" },
 ]
@@ -120,14 +134,18 @@ dev = [
 requires-dist = [
     { name = "django", specifier = ">=5.2" },
     { name = "django-cors-headers", specifier = ">=4.7.0" },
+    { name = "django-environ", specifier = ">=0.12.0" },
+    { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "djangorestframework-simplejwt", specifier = ">=5.5.0" },
     { name = "psycopg", specifier = ">=3.2.6" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-django", specifier = ">=4.11.1" },
     { name = "requests", specifier = ">=2.32.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.5" },
     { name = "strawberry-graphql", specifier = ">=0.264.0" },
     { name = "strawberry-graphql-django", specifier = ">=0.58.0" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.11.5" }]
+provides-extras = ["dev"]
 
 [[package]]
 name = "django-cors-headers"
@@ -140,6 +158,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/6c/16f6cb6064c63074fd5b2bd494eb319afd846236d9c1a6c765946df2c289/django_cors_headers-4.7.0.tar.gz", hash = "sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b", size = 21037 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/a2/7bcfff86314bd9dd698180e31ba00604001606efb518a06cca6833a54285/django_cors_headers-4.7.0-py3-none-any.whl", hash = "sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070", size = 12794 },
+]
+
+[[package]]
+name = "django-environ"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/04/65d2521842c42f4716225f20d8443a50804920606aec018188bbee30a6b0/django_environ-0.12.0.tar.gz", hash = "sha256:227dc891453dd5bde769c3449cf4a74b6f2ee8f7ab2361c93a07068f4179041a", size = 56804 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/b3/0a3bec4ecbfee960f39b1842c2f91e4754251e0a6ed443db9fe3f666ba8f/django_environ-0.12.0-py2.py3-none-any.whl", hash = "sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca", size = 19957 },
+]
+
+[[package]]
+name = "djangorestframework"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/97/112c5a72e6917949b6d8a18ad6c6e72c46da4290c8f36ee5f1c1dcbc9901/djangorestframework-3.16.0.tar.gz", hash = "sha256:f022ff46613584de994c0c6a4aebbace5fd700555fbe9d33b865ebf173eba6c9", size = 1068408 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/3e/2448e93f4f87fc9a9f35e73e3c05669e0edd0c2526834686e949bb1fd303/djangorestframework-3.16.0-py3-none-any.whl", hash = "sha256:bea7e9f6b96a8584c5224bfb2e4348dfb3f8b5e34edbecb98da258e892089361", size = 1067305 },
+]
+
+[[package]]
+name = "djangorestframework-simplejwt"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "djangorestframework" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/1e/0d4439d0fa1d93599fbcfc56efdc02cbf012e3a4b4ef90c835e0a51017d4/djangorestframework_simplejwt-5.5.0.tar.gz", hash = "sha256:474a1b737067e6462b3609627a392d13a4da8a08b1f0574104ac6d7b1406f90e", size = 97946 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/b4/d1c1750aa7c8cc07e4974275f96b9b9b3a38e95ff734e14b4e97790c8974/djangorestframework_simplejwt-5.5.0-py3-none-any.whl", hash = "sha256:4ef6b38af20cdde4a4a51d1fd8e063cbbabb7b45f149cc885d38d905c5a62edb", size = 103480 },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
 ]
 
 [[package]]
@@ -161,12 +223,30 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
 ]
 
 [[package]]
@@ -180,6 +260,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/97/eea08f74f1c6dd2a02ee81b4ebfe5b558beb468ebbd11031adbf58d31be0/psycopg-3.2.6.tar.gz", hash = "sha256:16fa094efa2698f260f2af74f3710f781e4a6f226efe9d1fd0c37f384639ed8a", size = 156322 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7d/0ba52deff71f65df8ec8038adad86ba09368c945424a9bd8145d679a2c6a/psycopg-3.2.6-py3-none-any.whl", hash = "sha256:f3ff5488525890abb0566c429146add66b329e20d6d4835662b920cbbf90ac58", size = 199077 },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/68/ce067f09fca4abeca8771fe667d89cc347d1e99da3e093112ac329c6020e/pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c", size = 78825 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850", size = 22344 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/fb/55d580352db26eb3d59ad50c64321ddfe228d3d8ac107db05387a2fadf3a/pytest_django-4.11.1.tar.gz", hash = "sha256:a949141a1ee103cb0e7a20f1451d355f83f5e4a5d07bdd4dcfdd1fd0ff227991", size = 86202 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/ac/bd0608d229ec808e51a21044f3f2f27b9a37e7a0ebaca7247882e67876af/pytest_django-4.11.1-py3-none-any.whl", hash = "sha256:1b63773f648aa3d8541000c26929c1ea63934be1cfa674c76436966d73fe6a10", size = 25281 },
 ]
 
 [[package]]
@@ -279,6 +397,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/21/8fef166346bf5d035398974f98bd3c60b5f7d91ad98e5928b7bdacb1d623/strawberry_graphql_django-0.58.0.tar.gz", hash = "sha256:cc5e07e0da122e267715384dd049e4e77de53143b8f0222f35035a4138a24f9c", size = 78347 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/aa/72fa3d9e2b5d8240a3c9db3bfc7d1b186426343f1f097ab2e53ad9c4d565/strawberry_graphql_django-0.58.0-py3-none-any.whl", hash = "sha256:103dc281d337037a939b079c2cdc748ef7ebdc01a6fa1eb822285aef317c6830", size = 97644 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
 
 [[package]]

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/material": "^7.0.2",
         "@tanstack/react-query": "^5.72.2",
+        "axios": "^1.8.4",
         "graphql-request": "^7.1.2",
         "mini.css": "^3.0.1",
         "react": "^19.0.0",
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@tanstack/eslint-plugin-query": "^5.72.2",
+        "@types/axios": "^0.9.36",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
@@ -30,7 +32,8 @@
         "globals": "^15.15.0",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.24.1",
-        "vite": "^6.2.0"
+        "vite": "^6.2.0",
+        "vite-plugin-checker": "^0.9.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1803,6 +1806,13 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@types/axios": {
+      "version": "0.9.36",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
+      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2187,6 +2197,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2209,6 +2232,23 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
@@ -2289,6 +2329,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2336,6 +2389,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2364,6 +2433,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2458,6 +2539,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -2466,6 +2556,20 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2482,6 +2586,51 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2856,6 +3005,41 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2890,6 +3074,43 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2914,6 +3135,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graphemer": {
@@ -2953,6 +3186,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -3225,6 +3485,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3247,6 +3516,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mini.css": {
@@ -3306,6 +3596,36 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3506,6 +3826,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3628,6 +3954,20 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -3804,6 +4144,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3840,6 +4196,58 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -3922,6 +4330,19 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4036,6 +4457,88 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-plugin-checker": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.9.1.tgz",
+      "integrity": "sha512-neH3CSNWdkZ+zi+WPt/0y5+IO2I0UAI0NX6MaXqU/KxN1Lz6np/7IooRB6VVAMBa4nigqm1GRF6qNa4+EL5jDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "chokidar": "^4.0.3",
+        "npm-run-path": "^6.0.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "strip-ansi": "^7.1.0",
+        "tiny-invariant": "^1.3.3",
+        "tinyglobby": "^0.2.12",
+        "vscode-uri": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "@biomejs/biome": ">=1.7",
+        "eslint": ">=7",
+        "meow": "^13.2.0",
+        "optionator": "^0.9.4",
+        "stylelint": ">=16",
+        "typescript": "*",
+        "vite": ">=2.0.0",
+        "vls": "*",
+        "vti": "*",
+        "vue-tsc": "~2.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@biomejs/biome": {
+          "optional": true
+        },
+        "eslint": {
+          "optional": true
+        },
+        "meow": {
+          "optional": true
+        },
+        "optionator": {
+          "optional": true
+        },
+        "stylelint": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vls": {
+          "optional": true
+        },
+        "vti": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-checker/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^7.0.2",
     "@tanstack/react-query": "^5.72.2",
+    "axios": "^1.8.4",
     "graphql-request": "^7.1.2",
     "mini.css": "^3.0.1",
     "react": "^19.0.0",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@tanstack/eslint-plugin-query": "^5.72.2",
+    "@types/axios": "^0.9.36",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
@@ -32,6 +34,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vite-plugin-checker": "^0.9.1"
   }
 }

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -9,6 +9,8 @@ import NotFound from "./Screens/NotFound";
 import Review from "./Screens/Review";
 import BookDetails from "./Screens/BookDetails";
 import GlobalErrorBoundary from "./Screens/GlobalErrorBoundary";
+import { AuthProvider } from "./auth/AuthProvider";
+import { LoginScreen } from "./Screens/LoginScreen";
 
 // TODO: split into different routers per children to have them cleaner e.g. Books, App, Reviews, etc.
 const router = createBrowserRouter([
@@ -20,6 +22,10 @@ const router = createBrowserRouter([
         // Redirect by default to /reviews
         index: true,
         element: <Navigate to="/reviews" replace />,
+      },
+      {
+        path: "login",
+        element: <LoginScreen />,
       },
       {
         path: "reviews",
@@ -52,8 +58,10 @@ const queryClient = new QueryClient();
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <h1>Platonica</h1>
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <h1>Platonica</h1>
+        <RouterProvider router={router} />
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/web-app/src/Screens/BookCover.tsx
+++ b/web-app/src/Screens/BookCover.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { styled } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 

--- a/web-app/src/Screens/BookDetails.tsx
+++ b/web-app/src/Screens/BookDetails.tsx
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { gql } from "graphql-request";
-import { graphQLClient } from "../graphqlClient";
 import { useOutletContext } from "react-router-dom";
 import { Alert, Box, Typography, CircularProgress } from "@mui/material";
 import BookCover from "./BookCover";
 import { ReviewLayoutContext } from "../types";
+import { useAuthGraphql } from "../hooks/useAuthGraphql";
 
 const GetBookQuery = gql`
   query GetBook($bookUuid: UUID!) {
@@ -19,11 +19,12 @@ const GetBookQuery = gql`
 `;
 
 function BookDetails() {
+  const client = useAuthGraphql();
   const { bookUuid } = useOutletContext<ReviewLayoutContext>();
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["book", bookUuid],
-    queryFn: () => graphQLClient.request(GetBookQuery, { bookUuid }),
+    queryFn: () => client.request(GetBookQuery, { bookUuid }),
     enabled: !!bookUuid,
   });
 

--- a/web-app/src/Screens/LoginScreen.tsx
+++ b/web-app/src/Screens/LoginScreen.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { useAuth } from "../hooks/useAuth";
+import { useNavigate } from "react-router-dom";
+import { login as apiLogin, TokenResponse } from "../auth/auth";
+import { useMutation } from "@tanstack/react-query";
+
+export function LoginScreen() {
+  const navigate = useNavigate();
+  const { access } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const loginMutation = useMutation<
+    TokenResponse, // TData
+    Error,
+    { username: string; password: string } // TVariables
+  >({
+    mutationFn: ({ username, password }) => apiLogin(username, password),
+    onSuccess: () => {
+      // navigate once login succeeds
+      navigate("/reviews");
+    },
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await loginMutation.mutateAsync({ username, password });
+  };
+
+  if (access) {
+    return <p>You’re already logged in.</p>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      {loginMutation.error && (
+        <div style={{ color: "crimson" }}>{loginMutation.error.message}</div>
+      )}
+      <div>
+        <label>
+          Username
+          <br />
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Password
+          <br />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+      </div>
+      <button type="submit" disabled={loginMutation.isPending}>
+        {loginMutation.isPending ? "Logging in…" : "Log In"}
+      </button>
+    </form>
+  );
+}

--- a/web-app/src/Screens/Review.tsx
+++ b/web-app/src/Screens/Review.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { gql } from "graphql-request";
-import { graphQLClient } from "../graphqlClient";
 import { Outlet, useParams } from "react-router-dom";
 import {
   Alert,
@@ -11,8 +10,8 @@ import {
   CardContent,
   Divider,
 } from "@mui/material";
-import BookDetails from "./BookDetails";
 import { ReviewLayoutContext } from "../types";
+import { useAuthGraphql } from "../hooks/useAuthGraphql";
 
 const GetBookQuery = gql`
   query GetBook($reviewUuid: UUID!) {
@@ -27,11 +26,12 @@ const GetBookQuery = gql`
 `;
 
 function Review() {
+  const client = useAuthGraphql();
   const { reviewUuid } = useParams<{ reviewUuid: string }>();
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["review", reviewUuid],
-    queryFn: () => graphQLClient.request(GetBookQuery, { reviewUuid }),
+    queryFn: () => client.request(GetBookQuery, { reviewUuid }),
     enabled: !!reviewUuid,
   });
 

--- a/web-app/src/Screens/Reviews.tsx
+++ b/web-app/src/Screens/Reviews.tsx
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { gql } from "graphql-request";
-import { graphQLClient } from "../graphqlClient";
 import BookCover from "./BookCover";
 import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
 import { useNavigate } from "react-router-dom";
+import { useAuthGraphql } from "../hooks/useAuthGraphql";
 
 const GetBookReviewsQuery = gql`
   query {
@@ -20,9 +20,10 @@ const GetBookReviewsQuery = gql`
 `;
 
 function Reviews() {
+  const client = useAuthGraphql();
   const { data, isLoading, isError } = useQuery({
     queryKey: ["reviews"],
-    queryFn: () => graphQLClient.request(GetBookReviewsQuery),
+    queryFn: () => client.request(GetBookReviewsQuery),
   });
 
   const navigate = useNavigate();

--- a/web-app/src/auth/AuthProvider.tsx
+++ b/web-app/src/auth/AuthProvider.tsx
@@ -1,0 +1,76 @@
+import { useState, ReactNode, useEffect } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { login, refreshToken, logout, TokenResponse } from "./auth";
+import { AuthContext } from "./utils";
+
+// AuthProvider Defines interface for JWT authentication
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [access, setAccess] = useState<string | null>(null);
+  const [refresh, setRefresh] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const loginMutation = useMutation<
+    TokenResponse,
+    Error,
+    { username: string; password: string }
+  >({
+    mutationFn: ({ username, password }) => login(username, password),
+    onSuccess(data) {
+      setAccess(data.access);
+      setRefresh(data.refresh);
+    },
+  });
+
+  const refreshMutation = useMutation<TokenResponse, Error, void>({
+    mutationFn: () => {
+      if (!refresh) throw new Error("No refresh token available");
+      return refreshToken(refresh);
+    },
+    onSuccess(data) {
+      setAccess(data.access);
+      setRefresh(data.refresh);
+    },
+    onError() {
+      // If refresh fails (expired/blacklisted), drop credentials
+      setAccess(null);
+      setRefresh(null);
+    },
+  });
+
+  const logoutMutation = useMutation<void, Error, void>({
+    mutationFn: () => {
+      if (!access || !refresh) return Promise.resolve();
+      return logout(access, refresh);
+    },
+    onSuccess() {
+      setAccess(null);
+      setRefresh(null);
+      queryClient.clear(); // clear any cached queries
+    },
+  });
+
+  // pull out only the mutate function (its identity is stable)
+  const { mutate: doRefresh } = refreshMutation;
+
+  // auto‑refresh on mount (if authenticated, refresh token is set in cookies)
+  useEffect(() => {
+    doRefresh(); // browser will send the refresh cookie
+  }, [doRefresh]);
+
+  // Public API
+  const loginFn = (username: string, password: string) =>
+    loginMutation.mutateAsync({ username, password });
+  const logoutFn = () => logoutMutation.mutateAsync();
+
+  return (
+    <AuthContext.Provider
+      value={{
+        access,
+        login: loginFn,
+        logout: logoutFn,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/web-app/src/auth/auth.ts
+++ b/web-app/src/auth/auth.ts
@@ -1,0 +1,42 @@
+// src/api/auth.ts
+import axios from "axios";
+
+const API_ROOT = import.meta.env.VITE_API_ROOT;
+
+export interface TokenResponse {
+  access: string;
+  refresh: string;
+}
+
+const api = axios.create({
+  baseURL: `${API_ROOT}/api`,
+  headers: { "Content-Type": "application/json" },
+  withCredentials: true, // set credentials in cookies
+});
+
+export async function login(
+  username: string,
+  password: string
+): Promise<TokenResponse> {
+  return await api
+    .post<TokenResponse>("/token/", { username, password })
+    .then((res) => res.data);
+}
+
+export async function refreshToken(refresh: string): Promise<TokenResponse> {
+  return await api
+    .post<TokenResponse>("/token/refresh/", { refresh })
+    .then((res) => res.data);
+}
+
+export async function logout(access: string, refresh: string) {
+  return await api
+    .post(
+      "/logout/",
+      { refresh },
+      {
+        headers: { Authorization: `Bearer ${access}` },
+      }
+    )
+    .then(() => {});
+}

--- a/web-app/src/auth/utils.ts
+++ b/web-app/src/auth/utils.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+import { TokenResponse } from "./auth";
+
+type AuthContextValue = {
+  access: string | null;
+  login: (username: string, password: string) => Promise<TokenResponse>;
+  logout: () => Promise<void>;
+};
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/web-app/src/graphqlClient.ts
+++ b/web-app/src/graphqlClient.ts
@@ -1,4 +1,0 @@
-import { GraphQLClient } from "graphql-request";
-
-const endpoint = "http://localhost:8000/app/graphql";
-export const graphQLClient = new GraphQLClient(endpoint);

--- a/web-app/src/hooks/useAuth.ts
+++ b/web-app/src/hooks/useAuth.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { AuthContext } from "../auth/utils";
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be inside AuthProvider");
+  return ctx;
+}

--- a/web-app/src/hooks/useAuthGraphql.ts
+++ b/web-app/src/hooks/useAuthGraphql.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+import { GraphQLClient } from "graphql-request";
+import { useAuth } from "./useAuth";
+
+const ENDPOINT = import.meta.env.VITE_API_ROOT + "/graphql";
+
+export function useAuthGraphql(): GraphQLClient {
+  const { access } = useAuth();
+
+  const clientRef = useRef(
+    new GraphQLClient(ENDPOINT, {
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+
+  // Update the Authorization header whenever `access` changes
+  useEffect(() => {
+    if (access) {
+      clientRef.current.setHeader("Authorization", `Bearer ${access}`);
+    } else {
+      // Reset headers if logged out
+      clientRef.current.setHeaders({ "Content-Type": "application/json" });
+    }
+  }, [access]);
+
+  return clientRef.current;
+}

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -1,7 +1,24 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import checker from "vite-plugin-checker";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+  plugins: [
+    react(),
+    checker({
+      typescript: true,
+      eslint: {
+        lintCommand: 'eslint "./src/**/*.{ts,tsx}"',
+        useFlatConfig: true,
+      },
+    }),
+  ],
+  clearScreen: false, // ← keep previous logs visible
+  logLevel: "info", // or 'debug' for even more detail
+  server: {
+    hmr: {
+      overlay: true, // ensure the error overlay is enabled
+    },
+  },
+});


### PR DESCRIPTION
### Now supported:
- Login Screen
- Authentication with db users using JWT 
- Token is stored in cookies
- Supports refresh and logout using blacklist (expires refresh tokens [active tokens would still be valid while it hasn't expired])
- A new env variable `GOOGLE_BOOKS_API_KEY` was added to avoid being rate limited by the service (a valid Google Cloud Key is needed)

### Three new apis were introduced:
- POST `api/token/`
- POST `api/token/refresh/`
- POST `api/logout/`

### JWT Cookie Authentication Flow:

1. username and password is sent to `api/token/`, server stores `access` and `refresh` tokens in Cookie with the same name.
2. Token in cookies is passed acrossed the requests. Backend reads the cookie and authenticates the request before proceeding.
3. When it expires, a post to `api/token/refresh` should be done [UI PENDING flow]. Which then stores a new set of `access` and `refresh` tokens as Cookies.
4. When login out [UI PENDING], a request is done to `api/logout` which invalidates the cookie and adds the refresh token to a blacklist so that client can't rotate the token.

Using jwt instead of session based allows us to not hit the db everytime to validate sessions (in memory validation). Also it works for multiplatform (once we have mobile).  The Blacklist method hits the db but only happens during logout not on every request. Right now it uses `HS256` algorithm but it can change to `RS256` once there needs to be inter-service communication.


<img width="195" alt="Screenshot 2025-04-20 at 10 27 08 PM" src="https://github.com/user-attachments/assets/9f1a524a-3919-4f8f-a6b0-584e98158a1f" />
<img width="903" alt="Screenshot 2025-04-20 at 10 27 34 PM" src="https://github.com/user-attachments/assets/901730f2-adbc-42d3-a8fd-fc0582d9e607" />
