### PR TITLE
Update image url fetching

### DIFF
--- a/app/dtos.py
+++ b/app/dtos.py
@@ -12,7 +12,6 @@ class BookInfo:
     date_finished: Optional[str] = None
     page_count: Optional[int] = None
     thumbnail_url: Optional[str] = None
-    small_thumbnail_url: Optional[str] = None
     image_small_url: Optional[str] = None
     image_medium_url: Optional[str] = None
     google_books_id: Optional[str] = None

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -44,7 +44,6 @@ class Query:
                 date_published=info.date_published,
                 page_count=info.page_count,
                 thumbnail_url=info.thumbnail_url,
-                small_thumbnail_url=info.small_thumbnail_url,
                 image_small_url=info.image_small_url,
                 image_medium_url=info.image_medium_url,
                 google_books_id=info.google_books_id,

--- a/app/graphql/types.py
+++ b/app/graphql/types.py
@@ -13,7 +13,6 @@ class BookInfoType:
     date_finished: Optional[str] = None
     page_count: Optional[int] = None
     thumbnail_url: Optional[str] = None
-    small_thumbnail_url: Optional[str] = None
     image_small_url: Optional[str] = None
     image_medium_url: Optional[str] = None
     google_books_id: Optional[str] = None

--- a/web-app/src/Screens/BookDetails.tsx
+++ b/web-app/src/Screens/BookDetails.tsx
@@ -34,13 +34,7 @@ function BookDetails() {
     );
   }
 
-  const {
-    title,
-    authors,
-    pageCount,
-    imageMediumUrl: imageUrl,
-    thumbnailUrl,
-  } = data.book;
+  const { title, authors, pageCount, imageMediumUrl, thumbnailUrl } = data.book;
 
   return (
     <Box p={4} display="flex" justifyContent="center">
@@ -53,7 +47,7 @@ function BookDetails() {
         >
           <BookCover
             bookName={title}
-            imageUrl={imageUrl || ""}
+            imageUrl={imageMediumUrl || ""}
             fallbackImageUrl={thumbnailUrl || ""}
             width={"100%"}
             height={"100%"}

--- a/web-app/src/Screens/Reviews.tsx
+++ b/web-app/src/Screens/Reviews.tsx
@@ -71,7 +71,7 @@ function Reviews() {
                         <BookCover
                           bookName={r.book?.title}
                           imageUrl={r.book?.thumbnailUrl || ""}
-                          fallbackImageUrl={r.book?.smallThumbnailUrl || ""}
+                          fallbackImageUrl={r.book?.imageSmallUrl || ""}
                           onClick={() => {
                             navigate(`/reviews/${rUUID}/book`);
                           }}

--- a/web-app/src/generated/graphql.ts
+++ b/web-app/src/generated/graphql.ts
@@ -129,7 +129,7 @@ export type GetReviewsQuery = {
       uuid: string;
       title: string;
       thumbnailUrl: string | null;
-      smallThumbnailUrl: string | null;
+      imageSmallUrl: string | null;
       authors: Array<string> | null;
     } | null;
   }>;
@@ -180,7 +180,7 @@ export const GetReviewsDocument = gql`
         uuid
         title
         thumbnailUrl
-        smallThumbnailUrl
+        imageSmallUrl
         authors
       }
     }

--- a/web-app/src/graphql/GetReviews.graphql
+++ b/web-app/src/graphql/GetReviews.graphql
@@ -5,7 +5,7 @@ query GetReviews {
       uuid
       title
       thumbnailUrl
-      smallThumbnailUrl
+      imageSmallUrl
       authors
     }
   }


### PR DESCRIPTION
Since google api sometimes returns default blank image urls for the links, we needed a better, more reliable way to have the cover image.

This uses a different endpoint which always gets the frontcover and just resizes it depending on the width and height parameters.

`https://books.google.com/books/content/images/frontcover/{VOLUME_ID}?fife=w{W}-h{H}`
